### PR TITLE
Update to Play 2.4.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: scala
 scala:
 - 2.11.7
 jdk:
-- openjdk7
-- oraclejdk7
 - oraclejdk8
 script: sbt coverage test
 after_success:

--- a/app/controllers/Template.scala
+++ b/app/controllers/Template.scala
@@ -42,8 +42,8 @@ object Template extends Controller {
         templateEngine.layout(path, vars).some.set(Vector.empty)
       }
       catch {
-        case _: ResourceNotFoundException => None.set(Vector(s"template $id not found"))
-        case e: TemplateException => None.set(Vector(s"invalid template: ${e.getMessage}"))
+        case _: ResourceNotFoundException => none[Content].set(Vector(s"template $id not found"))
+        case e: TemplateException => none[Content].set(Vector(s"invalid template: ${e.getMessage}"))
       }
     }
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,21 @@ version := "1.0-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 
+resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
+
 libraryDependencies ++= Seq(
   cache,
+  specs2 % Test,
   "org.scalatra.scalate" %% "scalate-core" % "1.7.1",
-  "org.scalaz" %% "scalaz-effect" % "7.0.6",
-  "org.scalaz" %% "scalaz-concurrent" % "7.0.6"
+  "org.scalaz" %% "scalaz-effect" % "7.1.6",
+  "org.scalaz" %% "scalaz-concurrent" % "7.1.6"
+)
+
+// see https://github.com/scalatra/scalatra/pull/325
+dependencyOverrides := Set(
+  "org.scala-lang" %  "scala-library"  % scalaVersion.value,
+  "org.scala-lang" %  "scala-reflect"  % scalaVersion.value,
+  "org.scala-lang" %  "scala-compiler" % scalaVersion.value
 )
 
 javaOptions in Test += "-Dconfig.file=test/template/test.conf"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -5,7 +5,7 @@
 # ~~~~~
 # The secret key is used to secure cryptographics functions.
 # If you deploy your application to several instances be sure to use the same key!
-application.secret="m6tBhKe9;Ln;YSwsZHUPWgDf;nv4_G0ybaydCb^/ek_NNtZpgEWX10Mcb?8GfAf`"
+play.crypto.secret="m6tBhKe9;Ln;YSwsZHUPWgDf;nv4_G0ybaydCb^/ek_NNtZpgEWX10Mcb?8GfAf`"
 
 # The application languages
 # ~~~~~

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.6")


### PR DESCRIPTION
Wow, this was hard. The `dependencyOverrides` prevents nasty reflection errors during template loading. Without that, you get exceptions like this one:
```scala
org.fusesource.scalate.TemplateException: scala.tools.nsc.Global$gen$.mkBlock(Lscala/collection/immutable/List;)Lscala/reflect/internal/Trees$Tree;
        at org.fusesource.scalate.TemplateEngine.compileAndLoad(TemplateEngine.scala:732)
        at org.fusesource.scalate.TemplateEngine.compileAndLoadEntry(TemplateEngine.scala:699)
        at org.fusesource.scalate.TemplateEngine.liftedTree1$1(TemplateEngine.scala:419)
        at org.fusesource.scalate.TemplateEngine.load(TemplateEngine.scala:413)
        at org.fusesource.scalate.TemplateEngine.load(TemplateEngine.scala:471)
...
```